### PR TITLE
Update the error messaging around invalid manifest

### DIFF
--- a/src/viewers/SimpleViewerContext.tsx
+++ b/src/viewers/SimpleViewerContext.tsx
@@ -214,7 +214,7 @@ export const SimpleViewerProvider: FC<{ manifest: string; pagingEnabled?: boolea
     [nextCanvas, previousCanvas, currentCanvasIndex, canvasList, setCurrentCanvasIndex, internalSetCurrentCanvasId]
   );
   
-  if(!manifest.mainfest) {
+  if(!manifest.manifest) {
     console.warn("The manifest passed to the provider is not a valid IIIF manifest.")
     return <div>Sorry, something went wrong.</div>
   }

--- a/src/viewers/SimpleViewerContext.tsx
+++ b/src/viewers/SimpleViewerContext.tsx
@@ -213,8 +213,13 @@ export const SimpleViewerProvider: FC<{ manifest: string; pagingEnabled?: boolea
       } as SimpleViewerContext),
     [nextCanvas, previousCanvas, currentCanvasIndex, canvasList, setCurrentCanvasIndex, internalSetCurrentCanvasId]
   );
+  
+  if(!manifest.mainfest) {
+    console.warn("The manifest passed to the provider is not a valid IIIF manifest.")
+    return <div>Sorry, something went wrong.</div>
+  }
 
-  if (!manifest.isLoaded || !manifest.manifest) {
+  if (!manifest.isLoaded) {
     return <div>Loading...</div>;
   }
 


### PR DESCRIPTION
Currently if you provide an invalid manifest or empty string as follows: 
```
 <SimpleViewerProvider manifest={""}>
     {rest of application}
 </SimpleViewerProvider>
```
The provider renders a div with 

"Loading..." 

The proposed change is to provide some guidance that an error has occured back to the user/developer. 